### PR TITLE
Rudimentary error handling for JSON encoder

### DIFF
--- a/src/encode/json.rs
+++ b/src/encode/json.rs
@@ -21,7 +21,9 @@ impl Json {
     where
         T: ?Sized + Serialize,
     {
-        to_vec(value).map(Into::into).map_err(|_err| todo!())
+        to_vec(value)
+            .map(Into::into)
+            .map_err(|err| EncodeError(Box::new(err)))
     }
 }
 
@@ -88,7 +90,7 @@ where
 
     #[inline]
     fn decode_all(&self, bytes: &[u8]) -> Result<Vec<T>, DecodeError> {
-        from_slice(bytes).map_err(|_err| todo!())
+        from_slice(bytes).map_err(|err| DecodeError(Box::new(err)))
     }
 
     /// Decode a single entry from a slice, if one exists.
@@ -103,7 +105,9 @@ where
         if bytes.is_empty() {
             Ok(None)
         } else {
-            from_slice(bytes).map(Some).map_err(|_err| todo!())
+            from_slice(bytes)
+                .map(Some)
+                .map_err(|err| DecodeError(Box::new(err)))
         }
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -89,8 +89,8 @@ impl From<ReqwestError> for ConnectionError {
 /// implement [`serde::de::Error`], e.g. [`serde::de::value::Error`], but that trait is not `dyn`
 /// compatible.
 #[derive(Debug, Error)]
-#[error(transparent)]
-pub struct DecodeError(#[from] pub BoxError);
+#[error("{0}")]
+pub struct DecodeError(#[source] pub BoxError);
 
 /// Errors that may occur when fetching entries. Created by methods of
 /// [`Source`](crate::connector::Source).
@@ -103,7 +103,7 @@ pub enum FetchError {
     /// Error occurred when processing query. The query was not valid or did not match the
     /// requested operation.
     // TODO: More information should be added here.
-    #[error("The query was not valid or did not match the requested operation.")]
+    #[error("The query was not valid or did not match the requested operation: {0}")]
     InvalidQuery(#[source] BoxError),
     /// Error occured during connection or communication.
     #[error(transparent)]
@@ -126,8 +126,8 @@ pub enum FetchOneError {
 /// An error that occured during encoding. The inner error is with many implementations likely to
 /// implement [`serde::ser::Error`], but that trait is not `dyn` compatible.
 #[derive(Debug, Error)]
-#[error(transparent)]
-pub struct EncodeError(#[from] pub BoxError);
+#[error("{0}")]
+pub struct EncodeError(#[source] pub BoxError);
 
 /// Errors that may occur when sending entries. Created by methods of
 /// [`Sink`](crate::connector::Sink).


### PR DESCRIPTION
Notes:
- `EncodeError` and `DecodeError` both currently wrap a `Box<dyn Error>`. It may be desirable in the future to include more information with the error.